### PR TITLE
Add commit ID to deployed app

### DIFF
--- a/app/config/_make_commit.sh
+++ b/app/config/_make_commit.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+commit=$(git rev-parse HEAD)
+printf "DEPLOYED_COMMIT = '$commit'"
+[ -d "$1" ] && printf "DEPLOYED_COMMIT = '$commit'" >"$1/app/config/commit.py"

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -133,3 +133,10 @@ STATIC_URL = '/static/'
 # https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+
+try:
+    # do _NOT_ create commit.py; this is used in deployment
+    from .commit import DEPLOYED_COMMIT  # type: ignore
+except ImportError:
+    DEPLOYED_COMMIT = '~development~'

--- a/app/host/templates/host/home.html
+++ b/app/host/templates/host/home.html
@@ -20,6 +20,8 @@
     <div>
     {% include 'host/host_form.html' %}
     </div>
+    <hr>
+    <div><p>Running from commit <code>{{ commit }}</code></p></div>
   </div>
 </div>
 {% endblock %}

--- a/app/host/views.py
+++ b/app/host/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.forms import ValidationError
 from django.http import HttpResponseRedirect, HttpResponseBadRequest
 from django.shortcuts import render
@@ -24,6 +25,7 @@ def host_home(request):
         'hosting': hosting,
         'uncurse_url': request.build_absolute_uri(reverse('uncurse')),
         'form': HostGameForm(),
+        'commit': settings.DEPLOYED_COMMIT,
     })
 
 


### PR DESCRIPTION
Without the deployment scripts, this is somewhat non-obvious.

In development, the `import` in `settings.py` fails, so the system always reports `~development~` for its commit. The deploy scripts, however, run `_make_commit.sh` pointing to a temporary deployment directory. This records the commit that was checked out for deployment.